### PR TITLE
[FEATURE] Preserve source channels order

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -620,7 +620,7 @@ All `/api/*` endpoints require either a valid session cookie or a `Authorization
 | `workerThreads` | `4` | Parallel workers for import processing |
 | `debug` | `false` | Enable verbose logging |
 | `obfuscateUrls` | `true` | Hide source URLs in logs |
-| `sortField` | `"tvg-name"` | Sort streams by attribute |
+| `sortField` | `"tvg-name"` | Sort streams by attribute; use `"preserve-order"` to keep source playlist/API order |
 | `sortDirection` | `"asc"` | Sort direction: `asc` or `desc` |
 | `streamTimeout` | `"10s"` | Global timeout for stream validation |
 | `maxConnectionsToApp` | `100` | Maximum total connections to the application |

--- a/static/admin.html
+++ b/static/admin.html
@@ -283,6 +283,7 @@
                                         <option value="tvg-chno">Channel #</option>
                                         <option value="tvg-country">Country</option>
                                         <option value="tvg-language">Language</option>
+                                        <option value="preserve-order">Preserve order</option>
                                     </select>
                                 </div>
                                 <div>

--- a/work/handlers/xcoutput.go
+++ b/work/handlers/xcoutput.go
@@ -83,10 +83,47 @@ func getSortedChannels(sp *proxy.StreamProxy) []xcChannelBatch {
 		batch = append(batch, xcChannelBatch{name, ch})
 		return true
 	})
-	sort.Slice(batch, func(i, j int) bool {
-		return strings.ToLower(batch[i].name) < strings.ToLower(batch[j].name)
-	})
+	if sp.Config.SortField == "preserve-order" {
+		sort.Slice(batch, func(i, j int) bool {
+			return xcChannelOriginalOrderLess(batch[i], batch[j])
+		})
+	} else {
+		sort.Slice(batch, func(i, j int) bool {
+			return strings.ToLower(batch[i].name) < strings.ToLower(batch[j].name)
+		})
+	}
 	return batch
+}
+
+func xcChannelOriginalOrderLess(a, b xcChannelBatch) bool {
+	aSourceOrder, aImportOrder := xcChannelOriginalOrder(a.channel)
+	bSourceOrder, bImportOrder := xcChannelOriginalOrder(b.channel)
+	if aSourceOrder != bSourceOrder {
+		return aSourceOrder < bSourceOrder
+	}
+	if aImportOrder != bImportOrder {
+		return aImportOrder < bImportOrder
+	}
+	return strings.ToLower(a.name) < strings.ToLower(b.name)
+}
+
+func xcChannelOriginalOrder(ch *types.Channel) (int, int) {
+	ch.Mu.RLock()
+	defer ch.Mu.RUnlock()
+
+	if len(ch.Streams) == 0 {
+		return int(^uint(0) >> 1), int(^uint(0) >> 1)
+	}
+
+	sourceOrder := ch.Streams[0].Source.Order
+	importOrder := ch.Streams[0].ImportOrder
+	for _, stream := range ch.Streams[1:] {
+		if stream.Source.Order < sourceOrder || (stream.Source.Order == sourceOrder && stream.ImportOrder < importOrder) {
+			sourceOrder = stream.Source.Order
+			importOrder = stream.ImportOrder
+		}
+	}
+	return sourceOrder, importOrder
 }
 
 // streamIDFromName generates a stable positive integer stream ID from a channel name

--- a/work/parser/m3u8.go
+++ b/work/parser/m3u8.go
@@ -513,6 +513,9 @@ func SortStreams(streams []*types.Stream, cfg *config.Config, channelName string
 		if s1.Source.Order != s2.Source.Order {
 			return s1.Source.Order < s2.Source.Order
 		}
+		if cfg.SortField == "preserve-order" {
+			return s1.ImportOrder < s2.ImportOrder
+		}
 		v1 := s1.Attributes[cfg.SortField]
 		v2 := s2.Attributes[cfg.SortField]
 		if cfg.SortDirection == "desc" {

--- a/work/proxy/stream.go
+++ b/work/proxy/stream.go
@@ -134,6 +134,37 @@ func (sp *StreamProxy) getChannelBatch() []channelBatch {
 	return batch
 }
 
+func channelOriginalOrderLess(a, b channelBatch) bool {
+	aSourceOrder, aImportOrder := channelOriginalOrder(a.channel)
+	bSourceOrder, bImportOrder := channelOriginalOrder(b.channel)
+	if aSourceOrder != bSourceOrder {
+		return aSourceOrder < bSourceOrder
+	}
+	if aImportOrder != bImportOrder {
+		return aImportOrder < bImportOrder
+	}
+	return strings.ToLower(a.name) < strings.ToLower(b.name)
+}
+
+func channelOriginalOrder(channel *types.Channel) (int, int) {
+	channel.Mu.RLock()
+	defer channel.Mu.RUnlock()
+
+	if len(channel.Streams) == 0 {
+		return int(^uint(0) >> 1), int(^uint(0) >> 1)
+	}
+
+	sourceOrder := channel.Streams[0].Source.Order
+	importOrder := channel.Streams[0].ImportOrder
+	for _, stream := range channel.Streams[1:] {
+		if stream.Source.Order < sourceOrder || (stream.Source.Order == sourceOrder && stream.ImportOrder < importOrder) {
+			sourceOrder = stream.Source.Order
+			importOrder = stream.ImportOrder
+		}
+	}
+	return sourceOrder, importOrder
+}
+
 // ImportStreams performs comprehensive stream discovery and aggregation from all configured
 // sources. Each source is fetched concurrently in its own goroutine, with connection
 // tracking and rate limiting enforced per-source. Discovered streams are filtered,
@@ -206,7 +237,8 @@ func (sp *StreamProxy) ImportStreams() {
 				logger.Debug("{proxy/stream - ImportStreams} Parsed %d streams from M3U8 source: %s", len(streams), utils.LogURL(sp.Config, src.URL))
 			}
 
-			for _, stream := range streams {
+			for importOrder, stream := range streams {
+				stream.ImportOrder = importOrder
 				channelName := stream.Name
 
 				channel, _ := newChannels.LoadOrStore(channelName, &types.Channel{
@@ -305,10 +337,16 @@ func (sp *StreamProxy) GeneratePlaylist(w http.ResponseWriter, r *http.Request, 
 	channels := sp.getChannelBatch()
 	logger.Debug("{proxy/stream - GeneratePlaylist} Building playlist from %d channels", len(channels))
 
-	// sort channels alphabetically by channel name
-	sort.SliceStable(channels, func(i, j int) bool {
-		return strings.ToLower(channels[i].name) < strings.ToLower(channels[j].name)
-	})
+	if sp.Config.SortField == "preserve-order" {
+		sort.SliceStable(channels, func(i, j int) bool {
+			return channelOriginalOrderLess(channels[i], channels[j])
+		})
+	} else {
+		// sort channels alphabetically by channel name
+		sort.SliceStable(channels, func(i, j int) bool {
+			return strings.ToLower(channels[i].name) < strings.ToLower(channels[j].name)
+		})
+	}
 
 	// pre-allocate the builder with a reasonable estimate
 	estimatedSize := len(channels) * 250

--- a/work/types/types.go
+++ b/work/types/types.go
@@ -51,6 +51,7 @@ type Stream struct {
 	ResolvedURL string               // For HLS master playlists, contains the selected variant URL
 	LastChecked time.Time            // Timestamp of most recent stream validation or health check
 	URLHash     string               // FNV64a hash of URL, assigned on import, never persisted
+	ImportOrder int                  // Original position within the imported source playlist/API response
 }
 
 // Channel represents a logical grouping of streams that provide the same content


### PR DESCRIPTION
In most cases, the original IPTV provider channel order is more logical and convenient.